### PR TITLE
README.mkdnの誤りの修正

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -21,9 +21,9 @@ HOW TO USE
 
 You type:
 
- $ cd atig
- $ ruby atig.rb -d
- I, [2010-04-05T07:22:07.861527 #62002]  INFO -- : Host: localhost Port:16668
+    $ cd atig
+    $ bin/atig -d
+    I, [2010-04-05T07:22:07.861527 #62002]  INFO -- : Host: localhost Port:16668
 
 and access localhost:16668 by Irc client.
 


### PR DESCRIPTION
README.mkdnのMarkdown書式が誤っていてpre要素による展開がなされていないようです。また記述も現状の仕様とはそぐわない物になっているので、合わせた修正をしました。
