### PR TITLE
Add interval option into the home timeline Agent

### DIFF
--- a/lib/atig/agent/timeline.rb
+++ b/lib/atig/agent/timeline.rb
@@ -4,11 +4,18 @@ require 'atig/agent/agent'
 module Atig
   module Agent
     class Timeline < Atig::Agent::Agent
+      DEFAULT_INTERVAL = 60
+
       def initialize(context, api, db)
-        return if context.opts.stream
+        @opts = context.opts
+        return if @opts.stream
         super
       end
-      def interval; 30 end
+
+      def interval
+        @interval ||= @opts.interval.nil? ? DEFAULT_INTERVAL : @opts.interval.to_i
+      end
+
       def path; '/statuses/home_timeline' end
       def source; :timeline end
     end


### PR DESCRIPTION
#37 ですが、これでそれらしい対応ができるのではないかなと思います。また初期値も 60 秒にしています。これは [REST API Rate Limiting in v1.1](https://dev.twitter.com/docs/rate-limiting/1.1) によれば各 API 単位で 15 分につき 15 リクエストまで、とのことなので一分に一度の取得にしてあります。
