### PR TITLE
Add description of a stream option into document

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -36,11 +36,16 @@ only
 
 発言関連
 ------------------------------
+stream
+  `UserStream`_ を有効にします。
+  実行中の変更には対応していません。
 footer=\ ``footer``
   発言の末尾に、 ``footer`` を追加します。
   ただし ``footer`` がfalseの場合は、追加しません。
 old_style_reply
   @nickで始まる発言が、@nick の最新の発言へのreplyとなるモードに切り替えます。
+
+.. _UserStream: https://dev.twitter.com/docs/streaming-apis/streams/user
 
 URL短縮関係
 ------------------------------


### PR DESCRIPTION
#37 に関連しまして、UserStream 追加に対する説明がドキュメントに不足しているかな? と思いましたので追加しました。文面になにか不足とかありましたら指摘してもらえると助かります。
