### PR TITLE
複数の短縮 URL を含むツイートで二つ目以降の短縮 URL 展開でエラーが発生してしまうのを修正

### DIFF
--- a/lib/atig/ifilter/expand_url.rb
+++ b/lib/atig/ifilter/expand_url.rb
@@ -17,9 +17,9 @@ module Atig
 
       def call(status)
         target = short_url_regexp
-        entities = status.entities
+        entities = (entities = status.entities).nil? ? [] : entities.urls
         status.merge :text => status.text.gsub(target) {|url|
-          unless entities.nil? or (entities = entities.urls).empty?
+          unless entities.nil? or entities.empty?
             @cache[url] ||= search_url_from_entities(url, entities)
           end
           @cache[url] ||= resolve_http_redirect(URI(url)).to_s || url

--- a/spec/ifilter/expand_url_spec.rb
+++ b/spec/ifilter/expand_url_spec.rb
@@ -71,9 +71,14 @@ describe Atig::IFilter::ExpandUrl, "when has urls entities" do
         "urls" => [{
           "url" => "http://t.co/1Vyoux4kB8",
           "expanded_url" => "http://example.com/"
+        }, {
+          "url" => "http://t.co/V1441ye6g2",
+          "expanded_url" => "http://example.org/"
         }]
       }
     }
     filtered("http://t.co/1Vyoux4kB8", opts).should be_text("http://example.com/")
+    filtered("http://t.co/1Vyoux4kB8 http://t.co/V1441ye6g2", opts).should
+      be_text("http://example.com/ http://expmaple.org/")
   end
 end


### PR DESCRIPTION
申しわけありません、 a38b7cadfd349dd74c71cca3d45f55eacbf4feb4 にてバグを入れてしまっていました。

こちら取り込んでいただけますと #42 も直るかと思われます。
