### PR TITLE
t.co 展開後の URL が短縮 URL だった場合にそちらの展開も行うように

### DIFF
--- a/lib/atig/ifilter/expand_url.rb
+++ b/lib/atig/ifilter/expand_url.rb
@@ -21,6 +21,7 @@ module Atig
         status.merge :text => status.text.gsub(target) {|url|
           unless entities.nil? or (entities = entities.urls).empty?
             @cache[url] ||= search_url_from_entities(url, entities)
+            url = @cache[url] if @cache[url] =~ target
           end
           @cache[url] ||= resolve_http_redirect(URI(url)).to_s || url
         }

--- a/spec/ifilter/expand_url_spec.rb
+++ b/spec/ifilter/expand_url_spec.rb
@@ -76,4 +76,16 @@ describe Atig::IFilter::ExpandUrl, "when has urls entities" do
     }
     filtered("http://t.co/1Vyoux4kB8", opts).should be_text("http://example.com/")
   end
+
+  it "should expand recursive shorten URL" do
+    opts = {
+      "entities" => {
+        "urls" => [{
+          "url" => "http://t.co/h8sqL5ZMuz",
+          "expanded_url" => "http://bit.ly/1LM4fW"
+        }]
+      }
+    }
+    filtered("http://t.co/h8sqL5ZMuz", opts).should be_text("[http://bit.ly/1LM4fW]")
+  end
 end


### PR DESCRIPTION
#43 の修正です。
