### PR TITLE
fix command line options "-v" and "--version"

### DIFF
--- a/lib/atig/optparse.rb
+++ b/lib/atig/optparse.rb
@@ -16,6 +16,7 @@ module Atig
         }
 
         OptionParser.new do |parser|
+          parser.version = Atig::VERSION
           parser.instance_eval do
             self.banner = <<EOB.gsub(/^\t+/, "")
 usage: #{$0} [opts]


### PR DESCRIPTION
fix probrem of https://github.com/atig/atig/issues/56

I understand that ["-h" option means "host" instead of "help"](https://github.com/atig/atig/blob/master/docs/commandline_options.rst)
