### PR TITLE
Fix encoding on finding statuses

### DIFF
--- a/lib/atig/db/statuses.rb
+++ b/lib/atig/db/statuses.rb
@@ -129,6 +129,8 @@ module Atig
 
       private
       def find(lhs,rhs, opt={},&f)
+        rhs.encoding!("UTF-8") if rhs.respond_to? :encoding!
+
         query  = "SELECT id,data FROM status WHERE #{lhs} = :rhs ORDER BY created_at DESC LIMIT :limit"
         params = { rhs: rhs, limit: opt.fetch(:limit,20) }
         res = []


### PR DESCRIPTION
PRIVMSGからコマンドを実行した際にtidでの検索が正常にされない問題を修正しました。
SQLite3::Database#executeのbind_varsにASCII-8BITで渡すとBLOB型として扱われるため、正常に検索されていませんでした。
