### PR TITLE
use Timeout.timeout instead of Object#timeout

### DIFF
--- a/lib/atig/db/transaction.rb
+++ b/lib/atig/db/transaction.rb
@@ -18,7 +18,7 @@ module Atig
 
           if respond_to?(:timeout_interval) && timeout_interval > 0 then
             begin
-              timeout(timeout_interval){ f.call self }
+              Timeout.timeout(timeout_interval){ f.call self }
             rescue TimeoutError
               debug "transaction is timeout at #{src}"
             end

--- a/lib/atig/twitter.rb
+++ b/lib/atig/twitter.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+require 'timeout'
 require 'atig/basic_twitter'
 require 'atig/http'
 
@@ -56,7 +57,7 @@ END
     end
 
     def oauth(time, req)
-      timeout(time) do
+      Timeout.timeout(time) do
         headers = {}
         req.each{|k,v| headers[k] = v }
 


### PR DESCRIPTION
I got ```Object#timeout is deprecated, use Timeout.timeout instead.``` with Ruby 2.3.0 trunk. 