### PR TITLE
Fix error on ruby 2.7

### DIFF
--- a/lib/atig/url_escape.rb
+++ b/lib/atig/url_escape.rb
@@ -36,18 +36,6 @@ class String
 end
 
 module URI::Escape
-  alias :_orig_escape :escape
-
-  if defined? ::RUBY_REVISION and RUBY_REVISION < 24544
-		# URI.escape("あ１") #=> "%E3%81%82\xEF\xBC\x91"
-    # URI("file:///４")  #=> #<URI::Generic:0x9d09db0 URL:file:/４>
-    #   "\\d" -> "[0-9]" for Ruby 1.9
-    def escape str, unsafe = %r{[^-_.!~*'()a-zA-Z0-9;/?:@&=+$,\[\]]} #'
-      _orig_escape(str, unsafe)
-    end
-    alias :encode :escape
-  end
-
   def encode_component(str, unsafe = ::OAuth::RESERVED_CHARACTERS)
     _orig_escape(str, unsafe).tr(" ", "+")
   end


### PR DESCRIPTION
RUBY_REVISION changed from Integer to String.
But the bug already fixed before Ruby 1.9.3 (minimum supported version mentioned in README.md).
So I simply remove it.

https://people.debian.org/~kanashiro/ruby2.7/builds/7/atig/atig_0.6.1-3+rebuild1580868080_amd64-2020-02-05T02:01:21Z.build.txt
```
An error occurred while loading ./spec/ofilter/escape_url_spec.rb.
Failure/Error: if defined? ::RUBY_REVISION and RUBY_REVISION < 24544

ArgumentError:
  comparison of String with 24544 failed
# ./lib/atig/url_escape.rb:41:in `<'
# ./lib/atig/url_escape.rb:41:in `<module:Escape>'
# ./lib/atig/url_escape.rb:38:in `<top (required)>'
# ./lib/atig/ofilter/escape_url.rb:5:in `<top (required)>'
# ./spec/ofilter/escape_url_spec.rb:3:in `<top (required)>'
```